### PR TITLE
Feat: Improve postCard types

### DIFF
--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -2,16 +2,10 @@ import Link from 'next/link';
 import { format } from 'date-fns';
 import { zhTW } from 'date-fns/locale';
 import Image from 'next/image';
-
-type PostCardProps = {
-  post: any
-  showTag?: boolean
-};
-
+import { PostCardProps } from '@/types/notion';
 export default function PostCard({ post, showTag = false }: PostCardProps) {
   // 從 Notion 頁面獲取標題
-  const title = post.properties.Title.title.map((text: any) => text.plain_text).join('');
-  
+  const title = post.properties.Title.title.map((text) => text.plain_text).join('');
   // 從 Notion 頁面獲取摘要
   const excerpt = post.properties.Excerpt?.rich_text
     ? post.properties.Excerpt.rich_text.map((text: any) => text.plain_text).join('')
@@ -27,7 +21,7 @@ export default function PostCard({ post, showTag = false }: PostCardProps) {
 
   const author = post.properties.Author?.rich_text[0]?.plain_text || '不具名';
 
-  const tag = post.properties.Category?.select.name || '無分類';
+  const tag = post.properties.Category.select?.name || '無分類';
 
 
   return (

--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -1,5 +1,6 @@
 import { Client } from '@notionhq/client';
 import { NotionAPI } from 'notion-client';
+import { NotionPost } from '@/types/notion';
 
 // 這裡需要填入您的 Notion 集成密鑰
 export const notion = new Client({
@@ -13,7 +14,7 @@ export const notionX = new NotionAPI();
 export const databaseId = process.env.NOTION_DATABASE_ID;
 
 // 取得部落格文章列表
-export async function getPosts(categoryQuery?: string) {
+export async function getPosts(categoryQuery?: string): Promise<NotionPost[]> {
 
   const categoryOption = {
     property: 'Category',
@@ -44,7 +45,7 @@ export async function getPosts(categoryQuery?: string) {
         ]}
     });
 
-    return response.results;
+    return response.results as unknown as NotionPost[];
   } catch (error) {
     console.error('Error fetching posts:', error);
     return [];

--- a/src/types/notion.ts
+++ b/src/types/notion.ts
@@ -1,0 +1,63 @@
+import { DatePropertyItemObjectResponse, SelectPropertyItemObjectResponse } from '@notionhq/client/build/src/api-endpoints';
+
+
+// Rich Text 項目的基礎型別
+export interface RichTextItem {
+  type: 'text';
+  text: {
+    content: string;
+    link: { url: string } | null;
+  };
+  annotations: {
+    bold: boolean;
+    italic: boolean;
+    strikethrough: boolean;
+    underline: boolean;
+    code: boolean;
+    color: string;
+  };
+  plain_text: string;
+  href: string | null;
+}
+
+// 實際的 Notion Title 屬性型別
+export interface ActualTitleProperty {
+  id: string;
+  type: 'title';
+  title: RichTextItem[];
+}
+
+// 實際的 Notion Rich Text 屬性型別
+export interface ActualRichTextProperty {
+  id: string;
+  type: 'rich_text';
+  rich_text: RichTextItem[];
+}
+
+// Notion Page 的封面圖片型別 - 符合實際 API 回應
+type ExternalPageCoverResponse = {
+  type: 'external'
+  external: { url: string },
+  file?: { [key: string]: string | undefined};
+}
+
+
+// 完整的 Notion Post 型別
+export interface NotionPost {
+  id: string;
+  cover?: ExternalPageCoverResponse;
+  properties: {
+    Title: ActualTitleProperty;
+    Published: DatePropertyItemObjectResponse;
+    Author: ActualRichTextProperty;
+    Category: SelectPropertyItemObjectResponse;
+    Excerpt: ActualRichTextProperty;
+    Status?: SelectPropertyItemObjectResponse;
+  };
+}
+
+// PostCard 組件的 Props 型別
+export interface PostCardProps {
+  post: NotionPost;
+  showTag?: boolean;
+}


### PR DESCRIPTION
# 導入 notion 官方型別

參考 @notionhq/client/build/src/api-endpoints 導入 API 回傳的資料格式並運用在 `postCard` 中，目前有部分型別無法正確吻合實際資料，暫時自行定義

```
  properties: {
    Title: ActualTitleProperty;
    Published: DatePropertyItemObjectResponse;
    Author: ActualRichTextProperty;
    Category: SelectPropertyItemObjectResponse;
    Excerpt: ActualRichTextProperty;
    Status?: SelectPropertyItemObjectResponse;
}
```