### PR TITLE
Fix: Image loading failure

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,18 +30,6 @@ const nextConfig = {
     ];
   },
   images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'www.notion.so',
-        pathname: '/**',
-      },
-      {
-        protocol: 'https',
-        hostname: 'prod-files-secure.s3.us-west-2.amazonaws.com',
-        pathname: '/**',
-      },
-    ],
     formats: ['image/webp'],
   },
 };

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -23,7 +23,7 @@ async function getPostHandler(id: string) {
   }
 }
 
-export const revalidate = 3600; // 每小時重新生成頁面
+export const revalidate = 3000;
 
 // 生成靜態路徑
 export async function generateStaticParams() {
@@ -113,18 +113,7 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
           <div className='mt-2 text-sm text-gray-600 dark:text-gray-200'>作者：{author}</div>
         </div>
 
-        {coverImage && (
-          <div className='mb-8'>
-            <Image
-              width={1000}
-              height={1000}
-              src={coverImage}
-              alt={title}
-              className='h-auto w-full rounded-lg shadow-md'
-            />
-          </div>
-        )}
-
+        {coverImage && <img src={coverImage} alt={title} className='h-auto w-full rounded-lg shadow-md' /> }
         <NotionPage recordMap={recordMap} />
       </article>
     </div>

--- a/src/app/posts/[id]/page.tsx
+++ b/src/app/posts/[id]/page.tsx
@@ -113,7 +113,9 @@ export default async function PostPage({ params }: { params: Promise<{ id: strin
           <div className='mt-2 text-sm text-gray-600 dark:text-gray-200'>作者：{author}</div>
         </div>
 
-        {coverImage && <img src={coverImage} alt={title} className='h-auto w-full rounded-lg shadow-md' /> }
+        {coverImage && (
+          <img src={coverImage} alt={title} className='h-auto w-full rounded-lg shadow-md' />
+        )}
         <NotionPage recordMap={recordMap} />
       </article>
     </div>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -33,14 +33,7 @@ export default function PostCard({ post, showTag = false }: PostCardProps) {
         </div>
       )}
       <div className='hidden h-48 overflow-hidden md:block'>
-        <Image
-          width={500}
-          height={500}
-          src={coverImage}
-          alt={title}
-          className='h-full w-full object-cover'
-          priority
-        />
+        <img src={coverImage} alt={title} className='h-full w-full object-cover' />
       </div>
       <div className='px-4 py-6'>
         <div className='hidden items-center justify-between md:flex'>


### PR DESCRIPTION
# 修正圖片載入錯誤

此問題初判是圖片 pre-signed-url 過期造成的錯誤，先用原生的 `img` tag，來避免next 在 build 階段 cached 圖片。

fixed: #32 

- 改用原生image tag
- 縮短重新fetch 資料的時間